### PR TITLE
Pretty Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ $ speedpack _dist
 packing [####################] 100%
 Finished in 5070ms
 Compressed:
-  File: 51 -> saved 0 bytes
-  Image: 31 -> saved 2922113 bytes
-  JavaScript: 1 -> saved 473 bytes
-  CSS: 3 -> saved 6031 bytes
+  File: 169 -> saved 0.00 Bytes (0%)
+  JavaScript: 1 -> saved 367.97 KB (0.356%)
+  Image: 4 -> saved 1.22 MB (0.145%)
+  CSS: 1 -> saved 397.14 KB (0.304%)
   -------------------------------
-  Total: 86 -> saved 2928617 bytes
+  Total: 175 -> saved 1.97 MB (0.550%)
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -15,18 +15,19 @@
   "dependencies": {
     "commander": "^2.9.0",
     "csso": "^2.2.1",
+    "file-size": "^1.0.0",
     "imagemin": "^5.2.2",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
+    "imagemin-mozjpeg": "latest",
     "imagemin-optipng": "^5.2.0",
+    "imagemin-pngquant": "latest",
     "imagemin-svgo": "^5.1.0",
     "mime": "^1.3.4",
     "mkdirp": "latest",
     "progress": "^1.1.8",
     "uglify-js": "^2.7.3",
-    "walk": "^2.3.9",
-    "imagemin-mozjpeg": "latest",
-    "imagemin-pngquant": "latest"
+    "walk": "^2.3.9"
   },
   "engines": {
     "node": ">=4"

--- a/src/cli.js
+++ b/src/cli.js
@@ -67,7 +67,7 @@ module.exports.go = function () {
     walker.on('end', function () {
         var progress = new ProgressBar('packing [:bar] :percent', {
             total: allPaths.length,
-            width: 20,
+            width: 40,
             complete: '#',
             incomplete: '-'
         });

--- a/src/cli.js
+++ b/src/cli.js
@@ -4,6 +4,7 @@ var walk = require('walk');
 var compressors = require('./compressors');
 var ProgressBar = require('progress');
 var version = require('../package.json').version;
+var filesize = require('file-size');
 
 
 module.exports.go = function () {
@@ -137,11 +138,12 @@ module.exports.go = function () {
 };
 
 function printFileTypeResult (fileType, result) {
-    var bytesSaved = result.readBytes - result.writtenBytes;
-    var percentSaved = result.writtenBytes / result.readBytes;
+    var bytesSaved = result.readBytes - result.writtenBytes
+    var storageSaved = filesize(bytesSaved).human('jedec');
+    var percentSaved = bytesSaved ? (result.writtenBytes / result.readBytes).toFixed(3) : '0';
 
     console.log(
         '  ' + fileType + ': ' + result.count +
-        ' -> saved ' + bytesSaved + ' bytes (' + percentSaved + ')'
+        ' -> saved ' + storageSaved + ' (' + percentSaved + '%)'
     );
 }


### PR DESCRIPTION
- Calculate file size in human-readable format
- Round percentages to 3dp
- Widen progress bar

### Example:
```
Compressed:
  File: 169 -> saved 0.00 Bytes (0%)
  JavaScript: 1 -> saved 367.97 KB (0.356%)
  Image: 4 -> saved 1.22 MB (0.145%)
  CSS: 1 -> saved 397.14 KB (0.304%)
  -------------------------------
  Total: 175 -> saved 1.97 MB (0.550%)
```